### PR TITLE
Responsive font inside of uw-client-checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "react-dom": "^17.0.0 || ^18.0.0",
         "react-file-picker": "^0.0.6",
         "react-router-dom": "^6.27.0",
-        "tc-checking-tool-rcl": "0.9.128",
+        "tc-checking-tool-rcl": "0.9.133",
         "usfm-js": "^3.4.3",
         "word-aligner-lib": "^1.0.1",
         "wordmap": "^0.6.1-beta.10"
@@ -13771,9 +13771,9 @@
       }
     },
     "node_modules/tc-checking-tool-rcl": {
-      "version": "0.9.128",
-      "resolved": "https://registry.npmjs.org/tc-checking-tool-rcl/-/tc-checking-tool-rcl-0.9.128.tgz",
-      "integrity": "sha512-IT6Js1QiQQ12lXYfgTQnxaZGKwlLrIaNqk00cGgmbwh2uhRqfx8fBoFyuW5DXDx6yKgCx5E1r7nhPlFgpS53yg==",
+      "version": "0.9.133",
+      "resolved": "https://registry.npmjs.org/tc-checking-tool-rcl/-/tc-checking-tool-rcl-0.9.133.tgz",
+      "integrity": "sha512-Syc43S/d4oZlo9A9Ldmsaff8WVZR7AOTuhb1bVJW8NJW4DfKYG6q25us8F7tJnqZ4zfAwefpBebqrDe49UnuhA==",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.13.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@gabrielaillet/word-aligner-rcl": "^1.3.18",
+        "@gabrielaillet/word-aligner-rcl": "^1.3.19",
         "@hello-pangea/dnd": "^18.0.1",
         "@mui/icons-material": "^6.5.0",
         "@mui/material": "^6.5.0",
@@ -2746,9 +2746,9 @@
       "license": "MIT"
     },
     "node_modules/@gabrielaillet/word-aligner-rcl": {
-      "version": "1.3.18",
-      "resolved": "https://registry.npmjs.org/@gabrielaillet/word-aligner-rcl/-/word-aligner-rcl-1.3.18.tgz",
-      "integrity": "sha512-wBhhTmY0coW5CAaJX3ZNZFP5Go8RE9QhekWcssfWPIJKpOT9nLevTm9zGNNDsqvugVHXnnJUduUFKH+P09t+mw==",
+      "version": "1.3.19",
+      "resolved": "https://registry.npmjs.org/@gabrielaillet/word-aligner-rcl/-/word-aligner-rcl-1.3.19.tgz",
+      "integrity": "sha512-/vIUmKHcjnX2Y/F6ONdQ1//uRRPapxPXCpv0NRw16Oc4ik6mgG+SPDFptt+2AJHxP+0NsbozL2IQYvxTIhg1iQ==",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.10.0",
@@ -7255,9 +7255,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-file-picker": "^0.0.6",
     "react-router-dom": "^6.27.0",
-    "tc-checking-tool-rcl": "0.9.128",
+    "tc-checking-tool-rcl": "0.9.133",
     "usfm-js": "^3.4.3",
     "word-aligner-lib": "^1.0.1",
     "wordmap": "^0.6.1-beta.10"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
-    "@gabrielaillet/word-aligner-rcl": "^1.3.18",
+    "@gabrielaillet/word-aligner-rcl": "^1.3.19",
     "@hello-pangea/dnd": "^18.0.1",
     "@mui/icons-material": "^6.5.0",
     "@mui/material": "^6.5.0",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -36,7 +36,7 @@ function AppLayout() {
   const [adjSelectedFontFamilies, setAdjSelectedFontFamilies] = useState(null);
   const [fontFamilyCorrespondance, setFontFamilyCorrespondance] =
     useState(null);
-
+  const [theme, setTheme] = useState(null);
   const isGraphite = GraphiteTest();
   useEffect(() => {
     if (fontFamilyCorrespondance) {
@@ -73,17 +73,42 @@ function AppLayout() {
       }).then();
     }
   });
-  const theme = useMemo(
-    () =>
-      createTheme({
-        ...themeSpec,
-        typography: {
-          ...themeSpec.typography,
-          fontFamily: fontFamily ? fontFamily.join(",") : "",
-        },
-      }),
-    [themeSpec, fontFamily],
-  );
+  useEffect(() => {
+    if (themeSpec && fontFamily) {
+      setTheme(
+        createTheme({
+          ...themeSpec,
+          typography: {
+            ...themeSpec.typography,
+            fontFamily: fontFamily.join(","),
+          },
+          components: {
+            ...themeSpec.components,
+
+            MuiTypography: {
+              styleOverrides: {
+                root: {
+                  fontFamily: fontFamily.join(","),
+                },
+              },
+            },
+
+            MuiListItemText: {
+              styleOverrides: {
+                primary: {
+                  fontFamily: fontFamily.join(","),
+                },
+                secondary: {
+                  fontFamily: fontFamily.join(","),
+                },
+              },
+            },
+          },
+        }),
+      );
+    }
+  }, [themeSpec, fontFamily]);
+
   useEffect(() => {
     let cores = {};
     document.fonts.ready.then(() => {
@@ -95,12 +120,32 @@ function AppLayout() {
   }, []);
 
   useEffect(() => {
-    document.body.style.setProperty(
-      "--accent-color-dark",
-      theme.palette.primary.main,
-    );
-    document.body.style.setProperty("--background-color-light", "#ffffff");
-  }, [theme.palette.primary.main]);
+    if (theme) {
+      document.body.style.setProperty(
+        "--accent-color-dark",
+        theme.palette.primary.main,
+      );
+      document.body.style.setProperty("--background-color-light", "#ffffff");
+    }
+  }, [theme]);
+
+  useEffect(() => {
+    if (!fontFamily?.length) return;
+
+    const style = document.createElement("style");
+
+    style.innerHTML = `
+    .MuiTypography-root {
+      font-family: ${fontFamily.join(",")} !important;
+    }
+  `;
+
+    document.head.appendChild(style);
+
+    return () => {
+      document.head.removeChild(style);
+    };
+  }, [fontFamily]);
   const CustomSnackbarContent = styled(MaterialDesignContent)(() => ({
     "&.notistack-MuiContent-error": {
       backgroundColor: "#FDEDED",
@@ -119,7 +164,7 @@ function AppLayout() {
       color: "#2E7D32",
     },
   }));
-  return (
+  return theme ? (
     <SnackbarProvider
       Components={{
         error: CustomSnackbarContent,
@@ -140,6 +185,8 @@ function AppLayout() {
         </Box>
       </ThemeProvider>
     </SnackbarProvider>
+  ) : (
+    <></>
   );
 }
 


### PR DESCRIPTION
Issue : https://github.com/orgs/pankosmia/projects/9?pane=issue&itemId=176724900&issue=pankosmia%7Croadmap%7C93
Changing style in setting should be changing the style inside the tools wordAlignment, wordsChecks 


also this issue was done : https://github.com/pankosmia/uw-client-checks/issues/47
No more toolbar at the bottom when translationAcademie is closed